### PR TITLE
Resolve pointing to a nonexist file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.1",
   "description": "A powerful Node.js library for interacting with the Guilded API.",
   "type": "commonjs",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "license": "MIT",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Resolves pointing to dist/index.js, which doesn't exist for dist/src/index.js.